### PR TITLE
Keep note search result when validation failed

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -4,10 +4,11 @@ class NotesController < ApplicationController
 
   def index
     @note_search_form = NoteSearchForm.new(search_params)
-    @notes = @note_search_form.search
-                              .order_by(params[:sort_column], params[:sort_direction])
-                              .page(params[:page])
+    note_ids = search_note_ids(@note_search_form)
 
+    @notes = Note.where(id: note_ids)
+                 .order_by(params[:sort_column], params[:sort_direction])
+                 .page(params[:page])
     @sort_column = params[:sort_column]
     @sort_direction = params[:sort_direction]
   end
@@ -64,5 +65,17 @@ class NotesController < ApplicationController
 
   def search_params
     params.fetch(:q, {}).permit(:title, :author, :start_date, :end_date)
+  end
+
+  # Cache search results if validation passed.
+  # if validation failed, return the last successful search result (if cache exist).
+  def search_note_ids(form)
+    if form.valid?
+      cache_key = SecureRandom.uuid
+      session[:last_valid_note_ids_search] = cache_key
+      form.search_ids(Note, cache_key)
+    else
+      Rails.cache.read(session[:last_valid_note_ids_search]) || []
+    end
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,13 +3,12 @@ class NotesController < ApplicationController
   before_action :set_note, only: %i[update destroy]
 
   def index
-    @note_search_form = NoteSearchForm.new(search_params)
     cache_key = "#{session.id}-#{self.class.name}"
-    note_ids = @note_search_form.search_ids(cache_key)
+    @note_search_form = NoteSearchForm.new(search_params, cache_key)
+    @notes = @note_search_form.search
+                              .order_by(params[:sort_column], params[:sort_direction])
+                              .page(params[:page])
 
-    @notes = Note.where(id: note_ids)
-                 .order_by(params[:sort_column], params[:sort_direction])
-                 .page(params[:page])
     @sort_column = params[:sort_column]
     @sort_direction = params[:sort_direction]
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -4,7 +4,7 @@ class NotesController < ApplicationController
 
   def index
     @note_search_form = NoteSearchForm.new(search_params)
-    note_ids = search_note_ids(@note_search_form)
+    note_ids = @note_search_form.search_ids(session)
 
     @notes = Note.where(id: note_ids)
                  .order_by(params[:sort_column], params[:sort_direction])
@@ -65,17 +65,5 @@ class NotesController < ApplicationController
 
   def search_params
     params.fetch(:q, {}).permit(:title, :author, :start_date, :end_date)
-  end
-
-  # Cache search results if validation passed.
-  # if validation failed, return the last successful search result (if cache exist).
-  def search_note_ids(form)
-    if form.valid?
-      cache_key = SecureRandom.uuid
-      session[:last_valid_note_ids_search] = cache_key
-      form.search_ids(Note, cache_key)
-    else
-      Rails.cache.read(session[:last_valid_note_ids_search]) || []
-    end
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -4,7 +4,8 @@ class NotesController < ApplicationController
 
   def index
     @note_search_form = NoteSearchForm.new(search_params)
-    note_ids = @note_search_form.search_ids(session)
+    cache_key = "#{session.id}-#{self.class.name}"
+    note_ids = @note_search_form.search_ids(cache_key)
 
     @notes = Note.where(id: note_ids)
                  .order_by(params[:sort_column], params[:sort_direction])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,10 +2,11 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(email: params[:email])
     @note_search_form = NoteSearchForm.new(search_params)
-    @notes = @note_search_form.search(@user.notes)
-                              .order_by(params[:sort_column], params[:sort_direction])
-                              .page(params[:page])
+    note_ids = search_note_ids(@note_search_form, @user)
 
+    @notes = Note.where(id: note_ids)
+                 .order_by(params[:sort_column], params[:sort_direction])
+                 .page(params[:page])
     @sort_column = params[:sort_column]
     @sort_direction = params[:sort_direction]
   end
@@ -14,5 +15,17 @@ class UsersController < ApplicationController
 
   def search_params
     params.fetch(:q, {}).permit(:title, :author, :start_date, :end_date)
+  end
+
+  # Cache search results if validation passed.
+  # if validation failed, return the last successful search result (if cache exist).
+  def search_note_ids(form, user)
+    if form.valid?
+      cache_key = SecureRandom.uuid
+      session[:last_valid_user_note_ids_search] = cache_key
+      form.search_ids(user.notes, cache_key)
+    else
+      Rails.cache.read(session[:last_valid_user_note_ids_search]) || []
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,13 +1,12 @@
 class UsersController < ApplicationController
   def show
     @user = User.find_by!(email: params[:email])
-    @note_search_form = NoteSearchForm.new(search_params, @user.notes)
     cache_key = "#{session.id}-#{self.class.name}"
-    note_ids = @note_search_form.search_ids(cache_key)
+    @note_search_form = NoteSearchForm.new(search_params, cache_key, @user.notes)
+    @notes = @note_search_form.search
+                              .order_by(params[:sort_column], params[:sort_direction])
+                              .page(params[:page])
 
-    @notes = Note.where(id: note_ids)
-                 .order_by(params[:sort_column], params[:sort_direction])
-                 .page(params[:page])
     @sort_column = params[:sort_column]
     @sort_direction = params[:sort_direction]
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,8 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(email: params[:email])
     @note_search_form = NoteSearchForm.new(search_params, @user.notes)
-    note_ids = @note_search_form.search_ids(session)
+    cache_key = "#{session.id}-#{self.class.name}"
+    note_ids = @note_search_form.search_ids(cache_key)
 
     @notes = Note.where(id: note_ids)
                  .order_by(params[:sort_column], params[:sort_direction])

--- a/app/forms/note_search_form.rb
+++ b/app/forms/note_search_form.rb
@@ -16,19 +16,18 @@ class NoteSearchForm
 
   # Cache search results if validation passed.
   # if validation failed, return the last successful search result (if cache exist).
-  def search_ids(session)
+  def search_ids(cache_key)
     if valid?
-      cache_key = SecureRandom.uuid
-      session[:last_valid_note_ids_search] = cache_key
-      Rails.cache.fetch(cache_key, expires_in: 5.minutes) do
-        notes = @base_scope.includes(:user)
-        notes = filter_by_title(notes)
-        notes = filter_by_author(notes)
-        notes = filter_by_updated_at(notes)
-        notes.pluck(:id)
-      end
+      notes = @base_scope.includes(:user)
+      notes = filter_by_title(notes)
+      notes = filter_by_author(notes)
+      notes = filter_by_updated_at(notes)
+      ids = notes.pluck(:id)
+
+      Rails.cache.write(cache_key, ids, expires_in: 5.minutes)
+      ids
     else
-      Rails.cache.read(session[:last_valid_note_ids_search]) || []
+      Rails.cache.read(cache_key) || []
     end
   end
 

--- a/app/forms/note_search_form.rb
+++ b/app/forms/note_search_form.rb
@@ -9,13 +9,16 @@ class NoteSearchForm
 
   validate :start_date_must_be_before_end_date
 
-  def search(base_scope = Note)
-    return base_scope.none if invalid? # Exec validation to receiver instance.
+  def search_ids(base_scope, key)
+    ids = Rails.cache.fetch(key, expires_in: 5.minutes) do
+      notes = base_scope.includes(:user)
+      notes = filter_by_title(notes)
+      notes = filter_by_author(notes)
+      notes = filter_by_updated_at(notes)
+      notes.pluck(:id)
+    end
 
-    notes = base_scope.includes(:user)
-    notes = filter_by_title(notes)
-    notes = filter_by_author(notes)
-    filter_by_updated_at(notes)
+    ids
   end
 
   private

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -8,7 +8,9 @@
 
 <%= form_with model: @note_search_form, scope: :q, url: notes_path, method: :get do |f| %>
   <%= render "shared/note_filter_errors", object: @note_search_form %>
-  <table class="note-table">
+
+  <%# Turn off prefetch function in table to prevent unintentional overwriting of search result cache. %>
+  <table class="note-table" data-turbo-prefetch="false">
     <thead>
       <tr>
         <th class="note-title">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,7 +20,9 @@
 
   <%= form_with model: @note_search_form, scope: :q, url: user_path(@user.email), method: :get do |f| %>
     <%= render "shared/note_filter_errors", object: @note_search_form %>
-    <table class="note-table">
+
+    <%# Turn off prefetch function in table to prevent unintentional overwriting of search result cache. %>
+    <table class="note-table" data-turbo-prefetch="false">
       <thead>
         <tr>
           <th class="note-title">

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -6,6 +6,7 @@ default: &default
     namespace: <%= Rails.env %>
 
 development:
+  database: cache
   <<: *default
 
 test:

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,8 +10,13 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  cache:
+    <<: *default
+    database: storage/development_cache.sqlite3
+    migrations_paths: db:cache_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   end
 
   # Change to :null_store to avoid any caching.
-  config.cache_store = :memory_store
+  config.cache_store = :solid_cache_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,6 +1,16 @@
-# frozen_string_literal: true
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 1) do
+ActiveRecord::Schema[8.0].define(version: 1) do
   create_table "solid_cache_entries", force: :cascade do |t|
     t.binary "key", limit: 1024, null: false
     t.binary "value", limit: 536870912, null: false

--- a/test/models/note_search_form_test.rb
+++ b/test/models/note_search_form_test.rb
@@ -6,52 +6,53 @@ class NoteSearchFormTest < ActiveSupport::TestCase
     @user2 = User.create!(email: "bbb@example.com", password: "password", confirmed_at: Time.now)
     @note1 = Note.create!(title: "aaa", updated_at: 1.days.ago, user: @user1)
     @note2 = Note.create!(title: "bbb", updated_at: 3.day.ago, user: @user2)
+    @cache_key = "dummy-cache-key"
   end
 
   test "should searchable by title" do
-    form = NoteSearchForm.new(title: "aaa")
-    result = form.search_ids("dummy-cache-key")
+    form = NoteSearchForm.new({ title: "aaa" }, @cache_key)
+    result = form.search
 
-    assert_includes result, @note1.id
-    assert_not_includes result, @note2.id
+    assert_includes result, @note1
+    assert_not_includes result, @note2
   end
 
   test "should searchable by author" do
-    form = NoteSearchForm.new(author: "aaa@example.com")
-    result = form.search_ids("dummy-cache-key")
+    form = NoteSearchForm.new({ author: "aaa@example.com" }, @cache_key)
+    result = form.search
 
-    assert_includes result, @note1.id
-    assert_not_includes result, @note2.id
+    assert_includes result, @note1
+    assert_not_includes result, @note2
   end
 
   test "should searchable by updated_at start date" do
-    form = NoteSearchForm.new(start_date: 2.days.ago.to_date)
-    result = form.search_ids("dummy-cache-key")
+    form = NoteSearchForm.new({ start_date: 2.days.ago.to_date }, @cache_key)
+    result = form.search
 
-    assert_includes result, @note1.id
-    assert_not_includes result, @note2.id
+    assert_includes result, @note1
+    assert_not_includes result, @note2
   end
 
   test "should searchable by updated_at end date" do
-    form = NoteSearchForm.new(end_date: 2.days.ago.to_date)
-    result = form.search_ids("dummy-cache-key")
+    form = NoteSearchForm.new({ end_date: 2.days.ago.to_date }, @cache_key)
+    result = form.search
 
-    assert_includes result, @note2.id
-    assert_not_includes result, @note1.id
+    assert_includes result, @note2
+    assert_not_includes result, @note1
   end
 
   test "should searchable by updated_at start and end date" do
     note3 = Note.create!(title: "ccc", updated_at: 5.day.ago, user: @user1)
-    form = NoteSearchForm.new(start_date: 4.days.ago.to_date, end_date: 2.days.ago.to_date)
-    result = form.search_ids("dummy-cache-key")
+    form = NoteSearchForm.new({ start_date: 4.days.ago.to_date, end_date: 2.days.ago.to_date }, @cache_key)
+    result = form.search
 
-    assert_includes result, @note2.id
-    assert_not_includes result, @note1.id
-    assert_not_includes result, note3.id
+    assert_includes result, @note2
+    assert_not_includes result, @note1
+    assert_not_includes result, note3
   end
 
   test "should be invalid when end_date is before start_date" do
-    form = NoteSearchForm.new(start_date: 2.days.ago.to_date, end_date: 4.days.ago.to_date)
+    form = NoteSearchForm.new({ start_date: 2.days.ago.to_date, end_date: 4.days.ago.to_date }, @cache_key)
     assert_not form.valid?
   end
 end

--- a/test/models/note_search_form_test.rb
+++ b/test/models/note_search_form_test.rb
@@ -10,44 +10,44 @@ class NoteSearchFormTest < ActiveSupport::TestCase
 
   test "should searchable by title" do
     form = NoteSearchForm.new(title: "aaa")
-    result = form.search
+    result = form.search_ids(Note, "dummy-cache-key")
 
-    assert_includes result, @note1
-    assert_not_includes result, @note2
+    assert_includes result, @note1.id
+    assert_not_includes result, @note2.id
   end
 
   test "should searchable by author" do
     form = NoteSearchForm.new(author: "aaa@example.com")
-    result = form.search
+    result = form.search_ids(Note, "dummy-cache-key")
 
-    assert_includes result, @note1
-    assert_not_includes result, @note2
+    assert_includes result, @note1.id
+    assert_not_includes result, @note2.id
   end
 
   test "should searchable by updated_at start date" do
     form = NoteSearchForm.new(start_date: 2.days.ago.to_date)
-    result = form.search
+    result = form.search_ids(Note, "dummy-cache-key")
 
-    assert_includes result, @note1
-    assert_not_includes result, @note2
+    assert_includes result, @note1.id
+    assert_not_includes result, @note2.id
   end
 
   test "should searchable by updated_at end date" do
     form = NoteSearchForm.new(end_date: 2.days.ago.to_date)
-    result = form.search
+    result = form.search_ids(Note, "dummy-cache-key")
 
-    assert_includes result, @note2
-    assert_not_includes result, @note1
+    assert_includes result, @note2.id
+    assert_not_includes result, @note1.id
   end
 
   test "should searchable by updated_at start and end date" do
     note3 = Note.create!(title: "ccc", updated_at: 5.day.ago, user: @user1)
     form = NoteSearchForm.new(start_date: 4.days.ago.to_date, end_date: 2.days.ago.to_date)
-    result = form.search
+    result = form.search_ids(Note, "dummy-cache-key")
 
-    assert_includes result, @note2
-    assert_not_includes result, @note1
-    assert_not_includes result, note3
+    assert_includes result, @note2.id
+    assert_not_includes result, @note1.id
+    assert_not_includes result, note3.id
   end
 
   test "should be invalid when end_date is before start_date" do

--- a/test/models/note_search_form_test.rb
+++ b/test/models/note_search_form_test.rb
@@ -10,7 +10,7 @@ class NoteSearchFormTest < ActiveSupport::TestCase
 
   test "should searchable by title" do
     form = NoteSearchForm.new(title: "aaa")
-    result = form.search_ids(Note, "dummy-cache-key")
+    result = form.search_ids("dummy-cache-key")
 
     assert_includes result, @note1.id
     assert_not_includes result, @note2.id
@@ -18,7 +18,7 @@ class NoteSearchFormTest < ActiveSupport::TestCase
 
   test "should searchable by author" do
     form = NoteSearchForm.new(author: "aaa@example.com")
-    result = form.search_ids(Note, "dummy-cache-key")
+    result = form.search_ids("dummy-cache-key")
 
     assert_includes result, @note1.id
     assert_not_includes result, @note2.id
@@ -26,7 +26,7 @@ class NoteSearchFormTest < ActiveSupport::TestCase
 
   test "should searchable by updated_at start date" do
     form = NoteSearchForm.new(start_date: 2.days.ago.to_date)
-    result = form.search_ids(Note, "dummy-cache-key")
+    result = form.search_ids("dummy-cache-key")
 
     assert_includes result, @note1.id
     assert_not_includes result, @note2.id
@@ -34,7 +34,7 @@ class NoteSearchFormTest < ActiveSupport::TestCase
 
   test "should searchable by updated_at end date" do
     form = NoteSearchForm.new(end_date: 2.days.ago.to_date)
-    result = form.search_ids(Note, "dummy-cache-key")
+    result = form.search_ids("dummy-cache-key")
 
     assert_includes result, @note2.id
     assert_not_includes result, @note1.id
@@ -43,7 +43,7 @@ class NoteSearchFormTest < ActiveSupport::TestCase
   test "should searchable by updated_at start and end date" do
     note3 = Note.create!(title: "ccc", updated_at: 5.day.ago, user: @user1)
     form = NoteSearchForm.new(start_date: 4.days.ago.to_date, end_date: 2.days.ago.to_date)
-    result = form.search_ids(Note, "dummy-cache-key")
+    result = form.search_ids("dummy-cache-key")
 
     assert_includes result, @note2.id
     assert_not_includes result, @note1.id


### PR DESCRIPTION
## 概要
SolidCacheを用いてnote検索失敗時に前の検索結果を保持する機能を追加しました。

## 作業内容
- development環境でのSolidCacheの有効化
- 検索失敗時に前の検索結果を保持する機能の追加
- 検索テストの修正

## 実装について
### 検索結果の保持方法について
Noteをテーブルで表示している画面はログイン不要で遷移、操作することができます。
表示しているユーザーごとに別々の検索結果を保持するために、sessionを用いて検索結果を保存するようにしました。
また、キャッシュの保存期間は今回のケースでは短い方が良いと判断し、5分に設定しました。

### prefetchの無効化について
ソートするリンクなどをホバーすると前回の検索結果がリセットされる問題がありました。
この問題の原因はrailsのprefetch機能でした。

prefetchはリンクをホバーしたタイミングでリクエストを送ることで高速化するturboの機能です。
今回の検索結果保持の実装ではindexアクションが実行されるタイミングで最新の検索結果をsessionに保存するようになっています。
prefetchによってindexアクションに遷移するリンクをホバーするだけでindexアクションにリクエストが走り、検索結果のリセットが行われてしまっていました。

HTML上のnoteテーブル内で、Railsのprefetch機能を無効化することで対応しました。
https://github.com/jdkim/nearnote/commit/c408127b1566c55400b2c8775800864a009b4d7c

## 動作確認
### Note一覧ページ

https://github.com/user-attachments/assets/d107a750-866d-4136-b83d-6bbf21b29a79

### User詳細ページ

https://github.com/user-attachments/assets/eed4ed6d-0496-4821-babd-4cb8a0bd6823
