### PR TITLE
Fix error in production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,8 +50,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  # config.active_job.queue_adapter = :solid_queue
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## 概要
production環境の動作確認を行いました。
サーバー起動時に以下のエラーが発生したため、その修正を行いサーバーが起動できるように修正しました。
```
undefined method 'solid_queue' for an instance of Rails::Application::Configuration (NoMethodError)
```

## 作業内容
- production.rbに残っていたsolid_queueの設定をコメントアウト

## 動作確認
### サーバーが起動できる
```
➜  nearnote git:(fix/fix_errors_in_production_environment) ✗ RAILS_ENV=production rails s
=> Booting Puma
=> Rails 8.0.1 application starting in production
=> Run `bin/rails server --help` for more startup options
[dotenv] Loaded .env
Puma starting in single mode...
* Puma version: 6.6.0 ("Return to Forever")
* Ruby version: ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [arm64-darwin24]
*  Min threads: 3
*  Max threads: 3
*  Environment: production
*          PID: 40222
* Listening on http://0.0.0.0:3000
Use Ctrl-C to stop
```